### PR TITLE
Do not track binary with git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ _testmain.go
 *.prof
 
 db/database.db
+
+/gouserapi


### PR DESCRIPTION
## WHY

After `go build`, generated binary file is detected as untracked file by Git.
This file (and most of binary files) should not be included in Git repository.

``` bash
$ go build
$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        gouserapi

nothing added to commit but untracked files present (use "git add" to track)
```
## WHAT

Add `gouserapi` to `.gitignore` not to track generated binary file.
