### PR TITLE
Fetch nation items correctly

### DIFF
--- a/controllers/nation.go
+++ b/controllers/nation.go
@@ -12,7 +12,7 @@ import (
 func GetNations(c *gin.Context) {
 	db := db.DBInstance(c)
 	fields := c.DefaultQuery("fields", "*")
-	var nations []models.Profile
+	var nations []models.Nation
 	db.Select(fields).Find(&nations)
 	c.JSON(200, nations)
 }


### PR DESCRIPTION
## WHY

`/api/nations` endpoint returns no item, even if Nation items exist.
## WHAT

Modify class name to bind
